### PR TITLE
Adjust types for complex permittivities

### DIFF
--- a/src/coordinateTransforms.jl
+++ b/src/coordinateTransforms.jl
@@ -8,7 +8,7 @@ All inputs are assumed do be in Cartesian coordinates.
 """
 function translate(points, translation::SVector{3,T}) where {T}
 
-    translation == SVector(0.0,0.0,0.0) && return points # no translation
+    translation == SVector{3,T}(0.0,0.0,0.0) && return points # no translation
 
     points_shifted = similar(points)
     for (ind, p) in enumerate(points)
@@ -28,7 +28,7 @@ The points are assumed do be in Cartesian coordinates.
 """
 function rotate!(points, rotation::SVector{2,T}) where {T}
 
-    rotation == SVector(0.0, 0.0) && return nothing # no rotation required
+    rotation == SVector{2,T}(0.0, 0.0) && return nothing # no rotation required
 
     # --- perform rotation
     wx = rotation[1] # rotation angle around x-axis (away from z-axis)
@@ -60,30 +60,34 @@ end
 
 function convertSpherical2Cartesian(F_sph, point_sph)
 
+    T = eltype(F_sph)
+
     sinϑ = sin(point_sph[2]) 
     cosϑ = cos(point_sph[2])
 
     sinϕ = sin(point_sph[3]) 
     cosϕ = cos(point_sph[3])
 
-    return SVector(F_sph[1] * sinϑ * cosϕ + F_sph[2] * cosϑ * cosϕ - F_sph[3] * sinϕ,
-                   F_sph[1] * sinϑ * sinϕ + F_sph[2] * cosϑ * sinϕ + F_sph[3] * cosϕ,
-                   F_sph[1] * cosϑ        - F_sph[2] * sinϑ )                                               
+    return SVector{3,T}(F_sph[1] * sinϑ * cosϕ + F_sph[2] * cosϑ * cosϕ - F_sph[3] * sinϕ,
+                        F_sph[1] * sinϑ * sinϕ + F_sph[2] * cosϑ * sinϕ + F_sph[3] * cosϕ,
+                        F_sph[1] * cosϑ        - F_sph[2] * sinϑ )                                               
 end
 
 
 # ----------------------- Convert the computed field from Cartesian to spherical representation
 function convertCartesian2Spherical(F_cart, point_sph)
 
+    T = eltype(F_sph)
+
     sinϑ = sin(point_sph[2]) 
     cosϑ = cos(point_sph[2])
 
     sinϕ = sin(point_sph[3]) 
     cosϕ = cos(point_sph[3])
 
-    return SVector( F_cart[1] * sinϑ * cosϕ + F_cart[2] * sinϑ * sinϕ + F_cart[3] * cosϑ,
-                    F_cart[1] * cosϑ * cosϕ + F_cart[2] * cosϑ * sinϕ - F_cart[3] * sinϑ,
-                   -F_cart[1] * sinϕ        + F_cart[2] * cosϕ )
+    return SVector{3,T}(F_cart[1] * sinϑ * cosϕ + F_cart[2] * sinϑ * sinϕ + F_cart[3] * cosϑ,
+                        F_cart[1] * cosϑ * cosϕ + F_cart[2] * cosϑ * sinϕ - F_cart[3] * sinϑ,
+                        -F_cart[1] * sinϕ        + F_cart[2] * cosϕ )
 end
 
 
@@ -92,11 +96,13 @@ function cart2sph(vec)
     y = vec[2]
     z = vec[3]
 
+    T = typeof(x)
+
     r = sqrt(x^2 + y^2 + z^2)
     t = (atan(sqrt(x^2 + y^2), z) + π) % π  # map to range [0, π]
     p = (atan(y, x) + 2 * π) % 2π                  # map to range [0, 2π]
 
-    return SVector(r, t, p)
+    return SVector{3,T}(r, t, p)
 end
 
 
@@ -105,9 +111,11 @@ function sph2cart(vec)
     ϑ = vec[2]
     ϕ = vec[3]
 
+    T = typeof(r)
+
     x = r * sin(ϑ) * cos(ϕ)
     y = r * sin(ϑ) * sin(ϕ)
     z = r * cos(ϑ)
 
-    return SVector(x, y, z)
+    return SVector{3,T}(x, y, z)
 end

--- a/src/dataHandling.jl
+++ b/src/dataHandling.jl
@@ -20,7 +20,7 @@ abstract type Excitation end
 
 struct Parameter
     nmax::Int
-    relativeAccuracy::Float64
+    relativeAccuracy::AbstractFloat
 end
 
 Parameter() = Parameter(-1, 1e-12)

--- a/src/dipoles/excitation.jl
+++ b/src/dipoles/excitation.jl
@@ -1,36 +1,36 @@
 
 abstract type Dipole <: Excitation end 
 
-struct HertzianDipole{T,C} <: Dipole
-    embedding::Medium{T}
-    wavenumber::T
-    amplitude::C
-    center::SVector{3,T}
-    orientation::SVector{3,T}
+struct HertzianDipole{T,R,C} <: Dipole
+    embedding::Medium{C}
+    wavenumber::R
+    amplitude::T
+    center::SVector{3,R}
+    orientation::SVector{3,R}
 end
 
-struct FitzgeraldDipole{T,C} <: Dipole
-    embedding::Medium{T}
-    wavenumber::T
-    amplitude::C
-    center::SVector{3,T}
-    orientation::SVector{3,T}
+struct FitzgeraldDipole{T,R,C} <: Dipole
+    embedding::Medium{C}
+    wavenumber::R
+    amplitude::T
+    center::SVector{3,R}
+    orientation::SVector{3,R}
 end
 
 HertzianDipole(;
 embedding   = Medium(ε0, μ0),
 wavenumber  = error("missing argument `wavenumber`"),
 amplitude   = 1.0,
-center      = SVector(0.0,0.0,0.0),
-orientation = SVector(0.0,0.0,1.0)
+center      = SVector{3,typeof(wavenumber)}(0.0,0.0,0.0),
+orientation = SVector{3,typeof(wavenumber)}(0.0,0.0,1.0)
 ) = HertzianDipole(embedding, wavenumber, amplitude, center, orientation)
 
 FitzgeraldDipole(;
 embedding   = Medium(ε0, μ0),
 wavenumber  = error("missing argument `wavenumber`"),
 amplitude   = 1.0,
-center      = SVector(0.0,0.0,0.0),
-orientation = SVector(0.0,0.0,1.0)
+center      = SVector{3,typeof(wavenumber)}(0.0,0.0,0.0),
+orientation = SVector{3,typeof(wavenumber)}(0.0,0.0,1.0)
 ) = FitzgeraldDipole(embedding, wavenumber, amplitude, center, orientation)
 
 

--- a/src/dipoles/incident.jl
+++ b/src/dipoles/incident.jl
@@ -6,7 +6,9 @@ Compute the electric field radiated by a magnetic/electric ring current at some 
 """
 function field(excitation::Dipole, quantity::Field; parameter::Parameter=Parameter())
 
-    F = zeros(SVector{3,Complex{Float64}}, length(quantity.locations))
+    T = typeof(excitation.wavenumber)
+
+    F = zeros(SVector{3,Complex{T}}, length(quantity.locations))
 
     # --- distinguish electric/magnetic current
     fieldType, exc = getFieldType(excitation, quantity)

--- a/src/planeWave/excitation.jl
+++ b/src/planeWave/excitation.jl
@@ -1,16 +1,16 @@
 
-struct PlaneWave{T,C} <: Excitation 
-    embedding::Medium{T}
-    wavenumber::C
-    amplitude::C
-    direction::SVector{3,T}
-    polarization::SVector{3,T}
+struct PlaneWave{T,R,C} <: Excitation
+    embedding::Medium{C}
+    wavenumber::R
+    amplitude::T
+    direction::SVector{3,R}
+    polarization::SVector{3,R}
 end
 
 planeWave(;
 embedding    = Medium(ε0, μ0),
 wavenumber   = error("missing argument `wavenumber`"),
 amplitude    = 1.0,
-direction    = SVector(0.0,0.0,-1.0),
-polarization = SVector(1.0,0.0,0.0)
+direction    = SVector{3,typeof(wavenumber)}(0.0,0.0,-1.0),
+polarization = SVector{3,typeof(wavenumber)}(1.0,0.0,0.0)
 ) = PlaneWave(embedding, wavenumber, amplitude, direction, polarization)

--- a/src/planeWave/incident.jl
+++ b/src/planeWave/incident.jl
@@ -6,7 +6,9 @@ Compute the electric field of a plane wave.
 """
 function field(excitation::PlaneWave, quantity::Field; parameter::Parameter=Parameter())
 
-    F = zeros(SVector{3,Complex{Float64}}, length(quantity.locations))
+    T = typeof(excitation.wavenumber)
+
+    F = zeros(SVector{3,Complex{T}}, length(quantity.locations))
 
     # --- compute field in Cartesian representation
     for (ind, point) in enumerate(quantity.locations)

--- a/src/planeWave/scattered.jl
+++ b/src/planeWave/scattered.jl
@@ -8,7 +8,9 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, quantity::Fiel
 
     sphere.embedding == excitation.embedding || error("Excitation and sphere are not in the same medium.") # verify excitation and sphere are in the same medium
 
-    F = zeros(SVector{3,Complex{Float64}}, size(quantity.locations))
+    T = typeof(excitation.wavenumber)
+
+    F = zeros(SVector{3,Complex{T}}, size(quantity.locations))
 
     # --- rotate coordinates
     # rotate!(points, -excitation.rotation)
@@ -38,16 +40,17 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     point_sph = cart2sph(point) # [r ϑ φ]
 
     k  = excitation.wavenumber
+    T = typeof(k)
 
     eps = parameter.relativeAccuracy
 
-    point_sph[1] <= sphere.radius && return SVector(complex(0.0), complex(0.0), complex(0.0)) # inside the sphere the field is 0
+    point_sph[1] <= sphere.radius && return SVector{3,Complex{T}}(0.0, 0.0, 0.0) # inside the sphere the field is 0
 
-    Er = complex(0.0)
-    Eϑ = complex(0.0)
-    Eϕ = complex(0.0)
+    Er = Complex{T}(0.0)
+    Eϑ = Complex{T}(0.0)
+    Eϕ = Complex{T}(0.0)
 
-    δE = Inf
+    δE = T(Inf)
     n = 0
 
     kr = k * point_sph[1]
@@ -59,9 +62,9 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     cosϕ = cos(point_sph[3]) 
 
     # first two values of the Associated Legendre Polynomial
-    plm = Vector{Float64}()
+    plm = Vector{T}()
     push!(plm, -sinϑ)
-    push!(plm, -3.0 * sinϑ * cosϑ)
+    push!(plm, -T(3.0) * sinϑ * cosϑ)
 
     s = sqrt(π / 2 / kr)
 
@@ -82,7 +85,7 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
 
             δE = (abs(ΔEr) + abs(ΔEϑ) + abs(ΔEϕ)) / (abs(Er) + abs(Eϑ) + abs(Eϕ)) # relative change
 
-            n > 1 && push!(plm, (2.0 * n + 1) * cosϑ * plm[n] / n - (n + 1) * plm[n - 1] / n) # recurrence relationship for next associated Legendre polynomials
+            n > 1 && push!(plm, (T(2.0) * n + 1) * cosϑ * plm[n] / n - (n + 1) * plm[n - 1] / n) # recurrence relationship for next associated Legendre polynomials
         end
     catch
 
@@ -106,19 +109,19 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     point_sph = cart2sph(point) # [r ϑ φ]
 
     k  = excitation.wavenumber
-
+    T = typeof(k)
     μ  = excitation.embedding.μ
     ε  = excitation.embedding.ε
 
     eps = parameter.relativeAccuracy
 
-    point_sph[1] <= sphere.radius && return SVector(complex(0.0), complex(0.0), complex(0.0)) # inside the sphere the field is 0
+    point_sph[1] <= sphere.radius && return SVector{3,Complex{T}}(0.0, 0.0, 0.0) # inside the sphere the field is 0
 
-    Hr = complex(0.0)
-    Hϑ = complex(0.0)
-    Hϕ = complex(0.0)
+    Hr = Complex{T}(0.0)
+    Hϑ = Complex{T}(0.0)
+    Hϕ = Complex{T}(0.0)
 
-    δH = Inf
+    δH = T(Inf)
     n = 0
 
     kr = k * point_sph[1]
@@ -130,9 +133,9 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     cosϕ = cos(point_sph[3]) 
 
     # first two values of the Associated Legendre Polynomial
-    plm = Vector{Float64}()
+    plm = Vector{T}()
     push!(plm, -sinϑ)
-    push!(plm, -3.0 * sinϑ * cosϑ)  
+    push!(plm, -T(3.0) * sinϑ * cosϑ)
     
     s = sqrt(π / 2 / kr)
 
@@ -153,7 +156,7 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
 
             δH = (abs(ΔHr) + abs(ΔHϑ) + abs(ΔHϕ)) / (abs(Hr) + abs(Hϑ) + abs(Hϕ)) # relative change
 
-            n > 1 && push!(plm, (2.0 * n + 1) * cosϑ * plm[n] / n - (n + 1) * plm[n - 1] / n) # recurrence relationship for next associated Legendre polynomials
+            n > 1 && push!(plm, (T(2.0) * n + 1) * cosϑ * plm[n] / n - (n + 1) * plm[n - 1] / n) # recurrence relationship for next associated Legendre polynomials
         end
     catch
 
@@ -176,7 +179,7 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     point_sph = cart2sph(point) # [r ϑ φ]
 
     k  = excitation.wavenumber
-
+    T = typeof(k)
     eps = parameter.relativeAccuracy
 
     sinϑ = abs(sin(point_sph[2]))  # note: theta only defined from from 0 to pi
@@ -185,16 +188,16 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     cosϕ = cos(point_sph[3]) 
 
     # first two values of the Associated Legendre Polynomial
-    plm = Vector{Float64}()
+    plm = Vector{T}()
     push!(plm, -sinϑ)
-    push!(plm, -3.0 * sinϑ * cosϑ)
+    push!(plm, -T(3.0) * sinϑ * cosϑ)
 
     ka = k * sphere.radius
 
-    Sϑ = complex(0.0)
-    Sϕ = complex(0.0)
+    Sϑ = Complex{T}(0.0)
+    Sϕ = Complex{T}(0.0)
 
-    δS = Inf
+    δS = T(Inf)
     n = 0
 
     try
@@ -208,7 +211,7 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
 
             δS = (abs(ΔSϑ) + abs(ΔSϕ)) / (abs(Sϑ) + abs(Sϑ)) # relative change
 
-            n > 1 && push!(plm, (2.0 * n + 1) * cosϑ * plm[n] / n - (n + 1) * plm[n - 1] / n) # recurrence relationship associated Legendre polynomial
+            n > 1 && push!(plm, (T(2.0) * n + 1) * cosϑ * plm[n] / n - (n + 1) * plm[n - 1] / n) # recurrence relationship associated Legendre polynomial
         end
     catch
 
@@ -218,7 +221,7 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     Eϕ = -Sϕ * sinϕ / k
 
     #return SVector(0.0, Eϑ, Eϕ)
-    return convertSpherical2Cartesian(SVector(0.0, Eϑ, Eϕ), point_sph)
+    return convertSpherical2Cartesian(SVector{3,Complex{T}}(0.0, Eϑ, Eϕ), point_sph)
 end
 
 
@@ -230,12 +233,13 @@ Compute scattering coefficients for a plane wave travelling in -z direction with
 """
 function scatterCoeff(sphere::PECSphere, excitation::PlaneWave, n::Int, ka)
 
+    T = typeof(excitation.wavenumber)
     s = sqrt(π / 2 / ka) 
 
-    J  = s * besselj(n + 0.5, ka)   # spherical Bessel function
-    H  = s * hankelh2(n + 0.5, ka)  # spherical Hankel function
-    J2 = s * besselj(n - 0.5, ka)  
-    H2 = s * hankelh2(n - 0.5, ka) 
+    J  = s * besselj(n + T(0.5), ka)   # spherical Bessel function
+    H  = s * hankelh2(n + T(0.5), ka)  # spherical Hankel function
+    J2 = s * besselj(n - T(0.5), ka)
+    H2 = s * hankelh2(n - T(0.5), ka)
 
     # [k₀ * a * j_n(k₀ a)]'
     kaJ1P = (ka * J2 - n * J )    # derivatives spherical Bessel functions
@@ -257,8 +261,10 @@ Compute functional dependencies of the Mie series for a plane wave travelling in
 """
 function expansion(sphere::PECSphere, excitation::PlaneWave, plm, kr, s, cosϑ, sinϑ, n::Int)
 
-    Hn  = s * hankelh2(n + 0.5, kr)     # spherical Hankel functions
-    H2n = s * hankelh2(n - 0.5, kr)
+    T = typeof(excitation.wavenumber)
+
+    Hn  = s * hankelh2(n + T(0.5), kr)     # spherical Hankel functions
+    H2n = s * hankelh2(n - T(0.5), kr)
 
     krH1Pn = kr * H2n - n * Hn          # derivatives spherical Hankel functions
 
@@ -266,9 +272,9 @@ function expansion(sphere::PECSphere, excitation::PlaneWave, plm, kr, s, cosϑ, 
 
     if abs(cosϑ) < 0.999999
         if n == 1 # derivative of associated Legendre Polynomial
-            dp = cosϑ * plm[1] / sqrt(1.0 - cosϑ * cosϑ)
+            dp = cosϑ * plm[1] / sqrt(T(1.0) - cosϑ * cosϑ)
         else
-            dp = (n * cosϑ * plm[n] - (n + 1) * plm[n - 1]) / sqrt(1.0 - cosϑ * cosϑ)
+            dp = (n * cosϑ * plm[n] - (n + 1) * plm[n - 1]) / sqrt(T(1.0) - cosϑ * cosϑ)
         end
 
         Mn_ϑ = Hn * p / sinϑ
@@ -278,7 +284,7 @@ function expansion(sphere::PECSphere, excitation::PlaneWave, plm, kr, s, cosϑ, 
         Nn_ϕ = krH1Pn * p  / (kr * sinϑ)
 
     elseif cosϑ > 0.999999
-        aux = (n + 1.0) * n / 2.0
+        aux = (n + T(1.0)) * n / T(2.0)
 
         Mn_ϑ = -Hn * aux
         Mn_ϕ = Mn_ϑ
@@ -287,7 +293,7 @@ function expansion(sphere::PECSphere, excitation::PlaneWave, plm, kr, s, cosϑ, 
         Nn_ϕ = Nn_ϑ
 
     elseif cosϑ < -0.999999
-        aux = (n + 1.0) * n / 2.0 * (-1.0)^n
+        aux = (n + T(1.0)) * n / T(2.0) * T(-1.0)^n
 
         Mn_ϑ =  Hn * aux
         Mn_ϕ = -Mn_ϑ
@@ -310,14 +316,15 @@ Compute far-field functional dependencies of the Mie series for a plane wave tra
 """
 function expansion(sphere::PECSphere, excitation::PlaneWave, ka, plm, cosϑ, sinϑ, n::Int)
     
+    T = typeof(excitation.wavenumber)
     An, Bn = scatterCoeff(sphere, excitation, n, ka)
 
     # derivative of associated Legendre Polynomial
     if abs(cosϑ) < 0.999999
         if n == 1
-            dp = cosϑ * plm[1] / sqrt(1.0 - cosϑ * cosϑ)
+            dp = cosϑ * plm[1] / sqrt(T(1.0) - cosϑ * cosϑ)
         else
-            dp = (n * cosϑ * plm[n] - (n + 1) * plm[n - 1]) / sqrt(1.0 - cosϑ * cosϑ)
+            dp = (n * cosϑ * plm[n] - (n + 1) * plm[n - 1]) / sqrt(T(1.0) - cosϑ * cosϑ)
         end
     end
 

--- a/src/ringCurrent/excitation.jl
+++ b/src/ringCurrent/excitation.jl
@@ -1,22 +1,22 @@
 
 abstract type RingCurrent <: Excitation end
 
-struct ElectricRingCurrent{T} <: RingCurrent
-    embedding::Medium{T}
-    wavenumber::T
+struct ElectricRingCurrent{T,R,C} <: RingCurrent
+    embedding::Medium{C}
+    wavenumber::R
     amplitude::T
-    radius::T
-    center::SVector{3,T}
-    rotation::SVector{2,T}
+    radius::R
+    center::SVector{3,R}
+    rotation::SVector{2,R}
 end
 
-struct MagneticRingCurrent{T} <: RingCurrent
-    embedding::Medium{T}
-    wavenumber::T
+struct MagneticRingCurrent{T,R,C} <: RingCurrent
+    embedding::Medium{C}
+    wavenumber::R
     amplitude::T
-    radius::T
-    center::SVector{3,T}
-    rotation::SVector{2,T}
+    radius::R
+    center::SVector{3,R}
+    rotation::SVector{2,R}
 end
 
 electricRingCurrent(;
@@ -24,8 +24,8 @@ embedding   = Medium(ε0, μ0),
 wavenumber  = error("missing argument `wavenumber`"),
 amplitude   = 1.0,
 radius      = error("missing argument `radius`"),
-center      = SVector(0.0,0.0,0.0),
-rotation    = SVector(0.0,0.0)
+center      = SVector{3,typeof(wavenumber)}(0.0,0.0,0.0),
+rotation    = SVector{2,typeof(wavenumber)}(0.0,0.0)
 ) = ElectricRingCurrent(embedding, wavenumber, amplitude, radius, center, rotation)
 
 magneticRingCurrent(;
@@ -33,8 +33,8 @@ embedding   = Medium(ε0, μ0),
 wavenumber  = error("missing argument `wavenumber`"),
 amplitude   = 1.0,
 radius      = error("missing argument `radius`"),
-center      = SVector(0.0,0.0,0.0),
-rotation    = SVector(0.0,0.0)
+center      = SVector{3,typeof(wavenumber)}(0.0,0.0,0.0),
+rotation    = SVector{2,typeof(wavenumber)}(0.0,0.0)
 ) = MagneticRingCurrent(embedding, wavenumber, amplitude, radius, center, rotation)
 
 

--- a/src/ringCurrent/incident.jl
+++ b/src/ringCurrent/incident.jl
@@ -7,7 +7,8 @@ Compute the electric field radiated by a magnetic/electric ring current at some 
 """
 function field(excitation::RingCurrent, quantity::Field; parameter::Parameter=Parameter())
 
-    F = zeros(SVector{3,Complex{Float64}}, length(quantity.locations))
+    T = typeof(excitation.wavenumber)
+    F = zeros(SVector{3,Complex{T}}, length(quantity.locations))
  
     # --- distinguish electric/magnetic current
     fieldType, exc = getFieldType(excitation, quantity)
@@ -42,13 +43,15 @@ function field(excitation::RingCurrent, point, quantity::ElectricField; paramete
     I0 = excitation.amplitude
     R  = excitation.radius
 
+    T = typeof(k)
+
     μ  = excitation.embedding.μ
     ε  = excitation.embedding.ε
 
     eps = parameter.relativeAccuracy
     
-    Eϕ = complex(0.0) # initialize
-    δE = Inf
+    Eϕ = Complex{T}(0.0) # initialize
+    δE = T(Inf)
     n  = -1
      
     r = point_sph[1]
@@ -56,9 +59,9 @@ function field(excitation::RingCurrent, point, quantity::ElectricField; paramete
     kr = k * r 
     kR = k * R
 
-    kr == 0.0 && return SVector(complex(0.0), complex(0.0), complex(0.0)) # in origin / at f=0 Hz the electric field is zero
+    kr == T(0.0) && return SVector{3,Complex{T}}(0.0, 0.0, 0.0) # in origin / at f=0 Hz the electric field is zero
     
-    cosθ = 0.0
+    cosθ = T(0.0)
     sinϑ = sin(point_sph[2]) 
     cosϑ = cos(point_sph[2])    
 
@@ -68,8 +71,8 @@ function field(excitation::RingCurrent, point, quantity::ElectricField; paramete
                 n += 2                      # (for z0=0 the even expansion_coeff are 0)
                 expansion_coeff = (2 * n + 1) / 2 / n / (n + 1) * dnPl(cosθ, n, 1) # variable part of expansion coefficients
                 
-                Jkr = besselj(n + 0.5, kr)  # Bessel function 1st kind 
-                HkR = hankelh2(n + 0.5, kR) # Hankel function 2nd kind
+                Jkr = besselj(n + T(0.5), kr)  # Bessel function 1st kind
+                HkR = hankelh2(n + T(0.5), kR) # Hankel function 2nd kind
                 
                 ΔE = expansion_coeff * HkR * Jkr * dnPl(cosϑ, n, 1)
                 δE = abs(ΔE / Eϕ)           # relative change 
@@ -82,8 +85,8 @@ function field(excitation::RingCurrent, point, quantity::ElectricField; paramete
                 n += 2                      # (for z0=0 the even expansion_coeff are 0)
                 expansion_coeff = (2 * n + 1) / 2 / n / (n + 1) * dnPl(cosθ, n, 1) # variable part of expansion coefficients
                                         
-                Hkr = hankelh2(n + 0.5, kr) # Hankel function 2nd kind
-                JkR = besselj(n + 0.5, kR)  # Bessel function 1st kind     
+                Hkr = hankelh2(n + T(0.5), kr) # Hankel function 2nd kind
+                JkR = besselj(n + T(0.5), kR)  # Bessel function 1st kind
                         
                 ΔE = expansion_coeff * Hkr * JkR * dnPl(cosϑ, n, 1)
                 δE = abs(ΔE / Eϕ)           # relative change 
@@ -113,14 +116,15 @@ function field(excitation::RingCurrent, point, quantity::MagneticField; paramete
     point_sph = cart2sph(point) # [r ϑ φ]
 
     k  = excitation.wavenumber
+    T = typeof(k)
     I0 = excitation.amplitude
     R  = excitation.radius
 
     eps = parameter.relativeAccuracy
     
-    Hr  = complex(0.0) # initialize
-    Hϑ  = complex(0.0) # initialize
-    δHr = Inf
+    Hr  = Complex{T}(0.0) # initialize
+    Hϑ  = Complex{T}(0.0) # initialize
+    δHr = T(Inf)
     n   = -1
      
     r = point_sph[1]
@@ -128,9 +132,9 @@ function field(excitation::RingCurrent, point, quantity::MagneticField; paramete
     kr = k * r 
     kR = k * R
 
-    kr == 0.0 && return SVector(complex(0.0), complex(0.0), complex(0.0)) # in origin / at f=0 Hz the field is zero
+    kr == T(0.0) && return SVector{3,Complex{T}}(0.0, 0.0, 0.0) # in origin / at f=0 Hz the field is zero
     
-    cosθ = 0.0
+    cosθ = T(0.0)
     sinϑ = sin(point_sph[2]) 
     cosϑ = cos(point_sph[2])    
 
@@ -140,9 +144,9 @@ function field(excitation::RingCurrent, point, quantity::MagneticField; paramete
                 n += 2                      # (for z0=0 the even expansion_coeff are 0)
                 expansion_coeff = (2 * n + 1) / 2  * dnPl(cosθ, n, 1) # variable part of expansion coefficients
                 
-                jkr = besselj(n + 0.5, kr)   # Bessel function 1st kind (without sqrt-term)
-                hkR = hankelh2(n + 0.5, kR)  # Hankel function 2nd kind (without sqrt-term)
-                jkrt = besselj(n + 1.5, kr)  # for derivative of Riccati-Bessel function 1st kind
+                jkr = besselj(n + T(0.5), kr)   # Bessel function 1st kind (without sqrt-term)
+                hkR = hankelh2(n + T(0.5), kR)  # Hankel function 2nd kind (without sqrt-term)
+                jkrt = besselj(n + T(1.5), kr)  # for derivative of Riccati-Bessel function 1st kind
 
                 dJkr = (n + 1) * sqrt(R / r) * jkr * hkR - k * sqrt(r * R) * hkR * jkrt  # HkR * derivative of Riccati-Bessel function 1st kind
                 
@@ -160,9 +164,9 @@ function field(excitation::RingCurrent, point, quantity::MagneticField; paramete
                 n += 2                       # (for z0=0 the even expansion_coeff are 0)
                 expansion_coeff = (2 * n + 1) / 2 * dnPl(cosθ, n, 1) # variable part of expansion coefficients
                                         
-                hkr = hankelh2(n + 0.5, kr)  # Hankel function 2nd kind (without sqrt-term)
-                jkR = besselj(n + 0.5, kR)   # Bessel function 1st kind (without sqrt-term)
-                hkrt = hankelh2(n + 1.5, kr) # for derivative of Riccati-Hankel function 2nd kind
+                hkr = hankelh2(n + T(0.5), kr)  # Hankel function 2nd kind (without sqrt-term)
+                jkR = besselj(n + T(0.5), kR)   # Bessel function 1st kind (without sqrt-term)
+                hkrt = hankelh2(n + T(1.5), kr) # for derivative of Riccati-Hankel function 2nd kind
                 
                 dHkr = (n + 1) * sqrt(R / r) * hkr * jkR - k * sqrt(r * R) * jkR * hkrt  # JkR * derivative of Riccati-Hankel function 2nd kind
                         
@@ -182,7 +186,7 @@ function field(excitation::RingCurrent, point, quantity::MagneticField; paramete
     Hr *= im * I0 * sqrt(R / r) / r * π / 2
     Hϑ *= -im * I0 * sinϑ / r * π / 2
 
-    return convertSpherical2Cartesian(SVector(Hr, Hϑ, 0.0), point_sph)
+    return convertSpherical2Cartesian(SVector{3,Complex{T}}(Hr, Hϑ, 0.0), point_sph)
 end
 
 
@@ -200,13 +204,15 @@ function field(excitation::RingCurrent, point, quantity::FarField; parameter::Pa
     I0 = excitation.amplitude
     R  = excitation.radius
     
+    T = typeof(k)
+
     μ  = excitation.embedding.μ
     ε  = excitation.embedding.ε
     
     eps = parameter.relativeAccuracy
     
-    Eϕ = complex(0.0) # initialize
-    δE = Inf
+    Eϕ = Complex{T}(0.0) # initialize
+    δE = T(Inf)
     n  = -1
     
     r = point_sph[1]
@@ -214,7 +220,7 @@ function field(excitation::RingCurrent, point, quantity::FarField; parameter::Pa
     kr = k * r 
     kR = k * R
     
-    cosθ = 0.0
+    cosθ = T(0.0)
     sinϑ = sin(point_sph[2]) 
     cosϑ = cos(point_sph[2])    
     
@@ -223,8 +229,8 @@ function field(excitation::RingCurrent, point, quantity::FarField; parameter::Pa
             n += 2                      # (for z0=0 the even expansion_coeff are 0)
             expansion_coeff = (2 * n + 1) / 2 / n / (n + 1) * dnPl(cosθ, n, 1) # variable part of expansion coefficients
                                         
-            Hkr = hankelh2(n + 0.5, kr) # Hankel function 2nd kind
-            JkR = besselj(n + 0.5, kR)  # Bessel function 1st kind     
+            Hkr = hankelh2(n + T(0.5), kr) # Hankel function 2nd kind
+            JkR = besselj(n + T(0.5), kR)  # Bessel function 1st kind
                         
             ΔE = expansion_coeff * Hkr * JkR * dnPl(cosϑ, n, 1)
             δE = abs(ΔE / Eϕ)           # relative change 
@@ -237,5 +243,5 @@ function field(excitation::RingCurrent, point, quantity::FarField; parameter::Pa
     
     Eϕ *= -I0 * sqrt(μ / ε) * sinϑ * k * sqrt(R / r) / 2 * π # constant factors
     
-    return SVector(-Eϕ*sin(point_sph[3]), Eϕ*cos(point_sph[3]), 0.0) # convert to Cartesian representation
+    return SVector{3,Complex{T}}(-Eϕ*sin(point_sph[3]), Eϕ*cos(point_sph[3]), 0.0) # convert to Cartesian representation
 end

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -1,20 +1,20 @@
 
-struct Medium{T}
-    ε::T
-    μ::T
+struct Medium{C}
+    ε::C
+    μ::C
 end
 
 abstract type Sphere end
 
-struct DielectricSphere{T} <: Sphere
-    radius::T
-    embedding::Medium{T}
-    filling::Medium{T}
+struct DielectricSphere{C,R} <: Sphere
+    radius::R
+    embedding::Medium{C}
+    filling::Medium{C}
 end
 
-struct PECSphere{T} <: Sphere
-    radius::T
-    embedding::Medium{T}
+struct PECSphere{C,R} <: Sphere
+    radius::R
+    embedding::Medium{C}
 end
 
 PECSphere(;

--- a/src/sphericalModes/excitation.jl
+++ b/src/sphericalModes/excitation.jl
@@ -1,26 +1,26 @@
 
 abstract type SphericalMode <: Excitation end 
 
-struct SphericalModeTE{T,C,In<:Integer} <: SphericalMode
-    embedding::Medium{T}
-    wavenumber::T
-    amplitude::C
+struct SphericalModeTE{T,R,C,In<:Integer} <: SphericalMode
+    embedding::Medium{C}
+    wavenumber::R
+    amplitude::T
     m::In
     n::In
     c::In
-    center::SVector{3,T}
-    orientation::SVector{3,T}
+    center::SVector{3,R}
+    orientation::SVector{3,R}
 end
 
-struct SphericalModeTM{T,C,In<:Integer} <: SphericalMode
-    embedding::Medium{T}
-    wavenumber::T
-    amplitude::C
+struct SphericalModeTM{T,R,C,In<:Integer} <: SphericalMode
+    embedding::Medium{C}
+    wavenumber::R
+    amplitude::T
     m::In
     n::In
     c::In
-    center::SVector{3,T}
-    orientation::SVector{3,T}
+    center::SVector{3,R}
+    orientation::SVector{3,R}
 end
 
 SphericalModeTE(;
@@ -30,8 +30,8 @@ amplitude   = 1.0,
 m           = 0,
 n           = 1,
 c           = 1,
-center      = SVector(0.0,0.0,0.0),
-orientation = SVector(0.0,0.0,1.0)
+center      = SVector{3,typeof(wavenumber)}(0.0,0.0,0.0),
+orientation = SVector{3,typeof(wavenumber)}(0.0,0.0,1.0)
 ) = SphericalModeTE(embedding, wavenumber, amplitude, m, n, c, center, orientation)
 
 SphericalModeTM(;
@@ -41,8 +41,8 @@ amplitude   = 1.0,
 m           = 0,
 n           = 1,
 c           = 1,
-center      = SVector(0.0,0.0,0.0),
-orientation = SVector(0.0,0.0,1.0)
+center      = SVector{3,typeof(wavenumber)}(0.0,0.0,0.0),
+orientation = SVector{3,typeof(wavenumber)}(0.0,0.0,1.0)
 ) = SphericalModeTM(embedding, wavenumber, amplitude, m, n, c, center, orientation)
 
 

--- a/src/sphericalModes/incident.jl
+++ b/src/sphericalModes/incident.jl
@@ -6,7 +6,8 @@ Compute the electric field of a spherical mode.
 """
 function field(excitation::SphericalMode, quantity::Field; parameter::Parameter=Parameter())
 
-    F = zeros(SVector{3,Complex{Float64}}, length(quantity.locations))
+    T = typeof(excitation.wavenumber)
+    F = zeros(SVector{3,Complex{T}}, length(quantity.locations))
 
     # --- distinguish electric/magnetic field
     fieldType, exc = getFieldType(excitation, quantity)
@@ -37,24 +38,26 @@ function field(excitation::SphericalModeTE, point, quantity::ElectricField; para
     μ  = excitation.embedding.μ
     ε  = excitation.embedding.ε
 
+    T = typeof(k)
+
     r = point_sph[1]
     ϑ = point_sph[2]
     ϕ = point_sph[3]
 
     kr = k * r
 
-    Er = Complex{Float64}(0.0)
-    Eϑ = Complex{Float64}(0.0)
-    Eϕ = Complex{Float64}(0.0)
+    Er = Complex{T}(0.0)
+    Eϑ = Complex{T}(0.0)
+    Eϕ = Complex{T}(0.0)
 
     # --- common factor
     pf = prefac(m, n)
 
     # --- Hankel functions
     if excitation.c == 1        # inward
-        H = hankelh1(n+0.5, kr) * sqrt(π / 2 / kr)
+        H = hankelh1(n+T(0.5), kr) * sqrt(π / 2 / kr)
     elseif excitation.c == 2    # outward
-        H = hankelh2(n+0.5, kr) * sqrt(π / 2 / kr)
+        H = hankelh2(n+T(0.5), kr) * sqrt(π / 2 / kr)
     else
         error("Type can only be 1 or 2.")
     end
@@ -68,7 +71,7 @@ function field(excitation::SphericalModeTE, point, quantity::ElectricField; para
     Eϕ = aux * derivatieAssociatedLegendre(n, m, ϑ)
 
     #return SVector(Er, Eϑ, Eϕ)
-    return convertSpherical2Cartesian(SVector(Er, Eϑ, Eϕ), point_sph) # convert to Cartesian representation
+    return convertSpherical2Cartesian(SVector{3,Complex{T}}(Er, Eϑ, Eϕ), point_sph) # convert to Cartesian representation
 end
 
 
@@ -89,26 +92,28 @@ function field(excitation::SphericalModeTM, point, quantity::ElectricField; para
     μ  = excitation.embedding.μ
     ε  = excitation.embedding.ε
 
+    T = typeof(k)
+
     r = point_sph[1]
     ϑ = point_sph[2]
     ϕ = point_sph[3]
 
     kr = k * r
 
-    Er = Complex{Float64}(0.0)
-    Eϑ = Complex{Float64}(0.0)
-    Eϕ = Complex{Float64}(0.0)
+    Er = Complex{T}(0.0)
+    Eϑ = Complex{T}(0.0)
+    Eϕ = Complex{T}(0.0)
 
     # --- common factor
     pf = prefac(m, n)
 
     # --- Hankel functions
     if excitation.c == 1        # inward
-        H  = hankelh1(n+0.5, kr)  
-        dH = (n + 1) * H - kr * hankelh1(n+1.5, kr)
+        H  = hankelh1(n+T(0.5), kr)
+        dH = (n + 1) * H - kr * hankelh1(n+T(1.5), kr)
     elseif excitation.c == 2    # outward
-        H  = hankelh2(n+0.5, kr) 
-        dH = (n + 1) * H - kr * hankelh2(n+1.5, kr)
+        H  = hankelh2(n+T(0.5), kr)
+        dH = (n + 1) * H - kr * hankelh2(n+T(1.5), kr)
     else
         error("Type can only be 1 or 2.")
     end
@@ -126,7 +131,7 @@ function field(excitation::SphericalModeTM, point, quantity::ElectricField; para
     Eϕ = -aux * dH * im * associatedLegendre(n, m, ϑ)
 
     #return SVector(Er, Eϑ, Eϕ)
-    return convertSpherical2Cartesian(SVector(Er, Eϑ, Eϕ), point_sph) # convert to Cartesian representation
+    return convertSpherical2Cartesian(SVector{3,Complex{T}}(Er, Eϑ, Eϕ), point_sph) # convert to Cartesian representation
 end
 
 
@@ -147,27 +152,29 @@ function field(excitation::SphericalModeTE, point, quantity::FarField; parameter
     μ  = excitation.embedding.μ
     ε  = excitation.embedding.ε
 
+    T = typeof(k)
+
     ϑ = point_sph[2]
     ϕ = point_sph[3]
 
 
-    Er = Complex{Float64}(0.0)
-    Eϑ = Complex{Float64}(0.0)
-    Eϕ = Complex{Float64}(0.0)
+    Er = Complex{T}(0.0)
+    Eϑ = Complex{T}(0.0)
+    Eϕ = Complex{T}(0.0)
 
     # --- common factor
     pf = prefac(m, n)
 
     # --- factors Eϑ and Eϕ have in common
     mabs = abs(m)
-    aux = -excitation.amplitude * (im)^(n+1) * 1.0 * sqrt(sqrt(μ / ε)) * pf * exp(-im * m * ϕ) * sqrt( (2*n + 1) / 2 * factorial(n-mabs) / factorial(n+mabs) )
+    aux = -excitation.amplitude * (im)^(n+1) * T(1.0) * sqrt(sqrt(μ / ε)) * pf * exp(-im * m * ϕ) * sqrt( (2*n + 1) / 2 * factorial(n-mabs) / factorial(n+mabs) )
 
     # --- put things together
     Eϑ = aux * im * associatedLegendre(n, m, ϑ)
     Eϕ = aux * derivatieAssociatedLegendre(n, m, ϑ)
 
     #return SVector(Er, Eϑ, Eϕ)
-    return convertSpherical2Cartesian(SVector(Er, Eϑ, Eϕ), point_sph) # convert to Cartesian representation
+    return convertSpherical2Cartesian(SVector{3,Complex{T}}(Er, Eϑ, Eϕ), point_sph) # convert to Cartesian representation
 end
 
 
@@ -188,26 +195,28 @@ function field(excitation::SphericalModeTM, point, quantity::FarField; parameter
     μ  = excitation.embedding.μ
     ε  = excitation.embedding.ε
 
+    T = typeof(k)
+
     ϑ = point_sph[2]
     ϕ = point_sph[3]
 
-    Er = Complex{Float64}(0.0)
-    Eϑ = Complex{Float64}(0.0)
-    Eϕ = Complex{Float64}(0.0)
+    Er = Complex{T}(0.0)
+    Eϑ = Complex{T}(0.0)
+    Eϕ = Complex{T}(0.0)
 
     # --- common factor
     pf = prefac(m, n)
 
     # --- factors Er, Eϑ, and Eϕ have in common
     mabs = abs(m)
-    aux = excitation.amplitude * (-im)^n * 1.0 * sqrt(sqrt(μ / ε)) * pf * exp(-im * m * ϕ) * sqrt( (2*n + 1) / 2 * factorial(n-mabs) / factorial(n+mabs) )  
+    aux = excitation.amplitude * (-im)^n * T(1.0) * sqrt(sqrt(μ / ε)) * pf * exp(-im * m * ϕ) * sqrt( (2*n + 1) / 2 * factorial(n-mabs) / factorial(n+mabs) )
 
     # --- put things together
     Eϑ = -aux * derivatieAssociatedLegendre(n, m, ϑ) 
     Eϕ =  aux * im * associatedLegendre(n, m, ϑ)
 
     #return SVector(Er, Eϑ, Eϕ)
-    return convertSpherical2Cartesian(SVector(Er, Eϑ, Eϕ), point_sph) # convert to Cartesian representation
+    return convertSpherical2Cartesian(SVector{3,Complex{T}}(Er, Eϑ, Eϕ), point_sph) # convert to Cartesian representation
 end
 
 
@@ -285,6 +294,6 @@ function derivatieAssociatedLegendre(n::T, m::T, ϑ::F) where {T <: Integer, F <
     mabs = abs(m)
 
     mabs == 0 && return Plm(cosϑ, n, 1) 
-    m == n && return 0.5 * ((n - mabs + 1)*(n + mabs) * (-1)^(mabs-1) * Plm(cosϑ, n, mabs - 1) )
-    return 0.5 * ((n - mabs + 1)*(n + mabs) * (-1)^(mabs-1) * Plm(cosϑ, n, mabs - 1) - (-1)^(mabs+1) * Plm(cosϑ, n, mabs + 1))
+    m == n && return F(0.5) * ((n - mabs + 1)*(n + mabs) * (-1)^(mabs-1) * Plm(cosϑ, n, mabs - 1) )
+    return F(0.5) * ((n - mabs + 1)*(n + mabs) * (-1)^(mabs-1) * Plm(cosϑ, n, mabs - 1) - (-1)^(mabs+1) * Plm(cosϑ, n, mabs + 1))
 end

--- a/src/sphericalModes/scattered.jl
+++ b/src/sphericalModes/scattered.jl
@@ -8,7 +8,9 @@ function scatteredfield(sphere::PECSphere, excitation::SphericalMode, quantity::
 
     sphere.embedding == excitation.embedding || error("Excitation and sphere are not in the same medium.") # verify excitation and sphere are in the same medium
 
-    F = zeros(SVector{3,Complex{Float64}}, size(quantity.locations))
+    T = typeof(excitation.wavenumber)
+
+    F = zeros(SVector{3,Complex{T}}, size(quantity.locations))
 
     # --- distinguish electric/magnetic current
     fieldType, exc = getFieldType(excitation, quantity)
@@ -63,8 +65,8 @@ end
 Compute scattering coefficients for a spherical TE mode travelling towards the origin.
 """
 function scatterCoeff(sphere::PECSphere, excitation::SphericalModeTE, n::Int, ka)
-
-    return -hankelh2(n+0.5, ka) / hankelh1(n+0.5, ka)
+    T = typeof(ka)
+    return -hankelh2(n+T(0.5), ka) / hankelh1(n+T(0.5), ka)
 end
 
 
@@ -76,8 +78,10 @@ Compute scattering coefficients for a spherical TM mode travelling towards the o
 """
 function scatterCoeff(sphere::PECSphere, excitation::SphericalModeTM, n::Int, ka)
 
-    dH1 = (n + 1) * hankelh1(n+0.5, ka) - ka * hankelh1(n+1.5, ka)
-    dH2 = (n + 1) * hankelh2(n+0.5, ka) - ka * hankelh2(n+1.5, ka)
+    T = typeof(ka)
+
+    dH1 = (n + 1) * hankelh1(n+T(0.5), ka) - ka * hankelh1(n+T(1.5), ka)
+    dH2 = (n + 1) * hankelh2(n+T(0.5), ka) - ka * hankelh2(n+T(1.5), ka)
 
     #dH1 = (n + 1) * besselj(n+0.5, ka) - ka * besselj(n+1.5, ka)
     #dH2 = (n + 1) * hankelh2(n+0.5, ka) - ka * hankelh2(n+1.5, ka)


### PR DESCRIPTION
Medium and radius no longer have to have the same type, enabling complex permittivities/permeabilities.

Also more flexibility in Float types/ no more hard-coded Float64.