### PR TITLE
Make plane-wave excitation Jin compatible

### DIFF
--- a/docs/src/planeWave.md
+++ b/docs/src/planeWave.md
@@ -62,10 +62,10 @@ FF = field(ex, FarField(point_cart))
 ---
 ## Scattered Field
 
-The scattered field computation follows [[2, pp. 141ff]](@ref refs). 
+The scattered field computation follows [[1, pp. 347ff]](@ref refs). 
 
 !!! warning
-    So far the plane wave is assumed to travel in negative ``z``-axis direction and to have a polarization along the ``x``-axis! This is planned to be generalized.
+    So far the plane wave is assumed to travel in positive ``z``-axis direction and to have a polarization along the ``x``-axis! This is planned to be generalized.
 
 #### API
 

--- a/src/planeWave/scattered.jl
+++ b/src/planeWave/scattered.jl
@@ -41,6 +41,8 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     point_sph = cart2sph(point) # [r ϑ φ]
 
     k = excitation.wavenumber
+    E₀ = excitation.amplitude
+
     T = typeof(k)
 
     eps = parameter.relativeAccuracy
@@ -93,8 +95,7 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
 
     end
 
-    #return SVector(Er, Eϑ, Eϕ)
-    return convertSpherical2Cartesian(SVector(Er, Eϑ, Eϕ), point_sph)
+    return convertSpherical2Cartesian(E₀ .* SVector(Er, Eϑ, Eϕ), point_sph)
 end
 
 
@@ -116,7 +117,7 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     μ = excitation.embedding.μ
     ε = excitation.embedding.ε
     η = sqrt(μ / ε)
-    H₀ = 1 / η # We assume that E₀ (defined in Jin (7.4.12)) is 1
+    H₀ = 1 / η * excitation.amplitude
 
     eps = parameter.relativeAccuracy
 
@@ -185,6 +186,8 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
     point_sph = cart2sph(point) # [r ϑ φ]
 
     k = excitation.wavenumber
+    E₀ = excitation.amplitude
+
     T = typeof(k)
     eps = parameter.relativeAccuracy
 
@@ -229,7 +232,7 @@ function scatteredfield(sphere::PECSphere, excitation::PlaneWave, point, quantit
 
     end
 
-    return convertSpherical2Cartesian(SVector{3,Complex{T}}(0.0, Eϑ, Eϕ), point_sph)
+    return convertSpherical2Cartesian(E₀ .* SVector{3,Complex{T}}(0.0, Eϑ, Eϕ), point_sph)
 end
 
 

--- a/test/planeWave.jl
+++ b/test/planeWave.jl
@@ -19,26 +19,25 @@
     @testset "Scattered fields" begin
 
         # ----- BEAST solution
-        𝐸 = Maxwell3D.planewave(; direction=-ẑ, polarization=x̂, wavenumber=κ)
+        𝐸 = Maxwell3D.planewave(; direction=ẑ, polarization=x̂, wavenumber=κ)
 
         𝑒 = n × 𝐸 × n
-        𝑇 = Maxwell3D.singlelayer(; wavenumber=κ)
+        𝑇 = Maxwell3D.singlelayer(; wavenumber=κ, alpha=-im * 𝜇 * (2π * f), beta=1 / (-im * 𝜀 * (2π * f)))
 
-        e = assemble(𝑒, RT)
+        e = -assemble(𝑒, RT)
         T = assemble(𝑇, RT, RT)
 
         u = T \ e
 
-        EF_MoM = potential(MWSingleLayerField3D(; wavenumber=κ), points_cartNF, u, RT)
+        EF_MoM = potential(MWSingleLayerField3D(𝑇), points_cartNF, u, RT)
         HF_MoM = potential(BEAST.MWDoubleLayerField3D(; wavenumber=κ), points_cartNF, u, RT)
-        FF_MoM = -im * f / (2 * c) * potential(MWFarField3D(; gamma=𝑇.gamma), points_cartFF, u, RT)
-
+        FF_MoM = -im * f / (2 * c) * potential(MWFarField3D(𝑇), points_cartFF, u, RT)
 
         # ----- this package
         sp = PECSphere(; radius=spRadius)
 
         EF = scatteredfield(sp, ex, ElectricField(points_cartNF))
-        HF = scatteredfield(sp, ex, MagneticField(points_cartNF)) * c * 𝜇
+        HF = scatteredfield(sp, ex, MagneticField(points_cartNF))
         FF = scatteredfield(sp, ex, FarField(points_cartFF))
 
 


### PR DESCRIPTION
Instead of sticking to an implementation based on Ruck, we now follow Jin's notation.

This change will help implementing a solution for dielectric problems, since Jin's book is much clearer on this

As a side effect, the sign error is gone too now.