### PR TITLE
Feature/thin impedance layer

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,3 +46,4 @@ The implementation is based on
 - [3] Sihvola, Ari & Lindell, Ismo., *Transmission Line Analogy for Calculating the Effective Permittivity of Mixtures with Spherical Multilayer Scatterers*, Journal of Electromagnetic Waves and Applications, Volume 2, Pages 741-756, 1988.
 - [4] J. D. Jackson, *Classical Electrodynamics*, New York: Wiley, 3rd ed., 1999.
 - [5] J. E. Hansen, ed., *Spherical Near-field Antenna Measurements*, The Institution of Engineering and Technology, Michael Faraday House, Six Hills Way, Stevenage SG1 2AY, UK: IET, 1988.
+- [6] T. B. Jones, Ed., *Models for layered spherical particles*, in Electromechanics of Particles, Cambridge: Cambridge University Press, 1995, pp. 227–235. doi: 10.1017/CBO9780511574498.012.

--- a/docs/src/scatterer.md
+++ b/docs/src/scatterer.md
@@ -41,6 +41,24 @@ DielectricSphere
 ```
 Here `radius` is a Float and `filling` of type [`Medium(εᵢ, μᵢ)`](@ref).
 
+---
+## Dielectric Sphere with Thin Impedance Layer
+
+The dielectric sphere with a thin impedance layer has radius $r$ and is assumed to be located in the origin. It is defined by [`DielectricSphereThinImpedanceLayer`](@ref). Unlike the LayeredSphere model, the solution is obtained by using an approximation: it is assumed that the impedance is so high that the displacement field is purely radial (see [[6, pp. 230ff]](@ref refs)). This leads to a potential drop across the thin layer, while the displacement field is constant in radial direction. In addition to the embedding [`Medium(ε, μ)`](@ref) and  filling [`Medium(εᵢ, μᵢ)`](@ref), the impedance layer must be specified, both the [`Medium`](@ref) and its `thickness`.  
+```@raw html
+<div align="center">
+<img src="../assets/DielectricSphere.svg" width="300"/>
+</div>
+<br/>
+```
+
+#### [API](@id dielecimpedAPI)
+
+```@docs
+DielectricSphereThinImpedanceLayer
+```
+Here `radius` and `thickness` are a Floats, `embedding`, `filling` and `thinlayer` are of type [`Medium`](@ref).
+
 
 ---
 ## Layered Dielectric Sphere

--- a/src/SphericalScattering.jl
+++ b/src/SphericalScattering.jl
@@ -32,7 +32,8 @@ export PlaneWave
 export UniformField
 export ElectricRingCurrent, MagneticRingCurrent
 export FarField, ElectricField, MagneticField
-export ScalarPotential
+export DisplacementField
+export ScalarPotential, ScalarPotentialJump
 export Medium, Parameter
 export μ0, ε0
 
@@ -42,6 +43,7 @@ export HertzianDipole, FitzgeraldDipole
 export planeWave
 export SphericalMode, SphericalModeTE, SphericalModeTM
 export PECSphere, DielectricSphere, LayeredSphere, LayeredSpherePEC
+export DielectricSphereThinImpedanceLayer
 export field, scatteredfield
 
 

--- a/src/UniformField/excitation.jl
+++ b/src/UniformField/excitation.jl
@@ -21,3 +21,7 @@ end
 """
 UniformField(; embedding=Medium(ε0, μ0), amplitude=1.0, direction=SVector{3,typeof(amplitude)}(1.0, 0.0, 0.0)) =
     UniformField(embedding, amplitude, direction)
+
+function orientation(ex::UniformField)
+    return ex.direction
+end

--- a/src/UniformField/incident.jl
+++ b/src/UniformField/incident.jl
@@ -6,7 +6,7 @@ Compute the field or potential of a uniform field.
 """
 function field(excitation::UniformField, quantity::Field; parameter::Parameter=Parameter())
 
-    F = zeros(fieldType(quantity), length(quantity.locations))
+    F = zeros(fieldType(quantity), size(quantity.locations))
 
     # --- compute field in Cartesian representation
     for (ind, point) in enumerate(quantity.locations)

--- a/src/UniformField/scattered.jl
+++ b/src/UniformField/scattered.jl
@@ -90,26 +90,27 @@ function scatteredfield(
     parameter::Parameter=Parameter(),
 )
 
-    ẑ = SVector(0.0, 0.0, 1.0)
-    # Currently, we only support a constant field in z-direction
-    @assert excitation.direction == ẑ
-
+    point = rotate(excitation, [point]; inverse=true)[1]
     point_sph = cart2sph(point)
-    θ = point_sph[2]
-
-    cosθ = dot(ẑ, point) / norm(point)
 
     r = norm(point)
+
+    ẑ = SVector(0.0, 0.0, 1.0) #excitation.direction
+    cosθ = dot(ẑ, point) / r
+    sinθ = norm(cross(ẑ, point)) / r
 
     A, K = scatterCoeff(sphere, excitation)
 
     if r > sphere.radius
-        E = -SVector((-2 * A / r^3) * cosθ, (+A / r^3) * (-sin(θ)), 0.0)
+        E = -SVector((-2 * A / r^3) * cosθ, (+A / r^3) * (-sinθ), 0.0)
     else
-        E = -SVector((-K * cosθ, K * sin(θ), 0.0))
+        E = -SVector((-K * cosθ, K * sinθ, 0.0))
     end
 
-    return convertSpherical2Cartesian(E, point_sph)
+    E_cart = convertSpherical2Cartesian(E, point_sph)
+
+    return rotate(excitation, [E_cart]; inverse=false)[1]
+
 end
 
 function scatteredfield(
@@ -151,15 +152,7 @@ function scatteredfield(
     parameter::Parameter=Parameter(),
 )
 
-    ẑ = SVector(0.0, 0.0, 1.0)
-    # Currently, we only support a constant field in z-direction
-    @assert excitation.direction == ẑ
-
-    point_sph = cart2sph(point)
-    θ = point_sph[2]
-
-    cosθ = dot(ẑ, point) / norm(point)
-    #@assert cosθ ≈ cos(point_sph[2]) atol = 1e-6
+    cosθ = dot(excitation.direction, point) / norm(point)
 
     ~, K = scatterCoeff(sphere, excitation)
 
@@ -184,11 +177,7 @@ function scatteredfield(
     parameter::Parameter=Parameter(),
 )
 
-    ẑ = SVector(0.0, 0.0, 1.0)
-    # Currently, we only support a constant field in z-direction
-    @assert excitation.direction == ẑ
-
-    cosθ = dot(ẑ, point) / norm(point)
+    cosθ = dot(excitation.direction, point) / norm(point)
     r = norm(point)
 
     R = sphere.radius

--- a/src/coordinateTransforms.jl
+++ b/src/coordinateTransforms.jl
@@ -91,9 +91,9 @@ end
 
 Determine rotation matrix for a dipole or a ring-current excitation via the Rodrigues formula. 
 """
-function rotationMatrix(excitation::Union{Dipole,RingCurrent})
+function rotationMatrix(excitation::Union{Dipole,RingCurrent,UniformField})
 
-    p = excitation.orientation # unit vector
+    p = orientation(excitation) # unit vector
     T = eltype(p)
 
     # --- p == ez  => no rotation
@@ -123,43 +123,6 @@ function rotationMatrix(excitation::Union{Dipole,RingCurrent})
     return R
 end
 
-
-# """
-#     rotationMatrix(excitation::UniformField)
-
-# Determine rotation matrix for a uniform field excitation via the Rodrigues formula. 
-# """
-# function rotationMatrix(excitation::UniformField)
-
-#     p = excitation.direction # unit vector
-#     T = eltype(p)
-
-#     # --- p == ex  => no rotation
-#     p == SVector{3,T}(1, 0, 0) && return nothing
-
-#     # --- rotation axis
-#     aux = SVector{3,T}(1, 0, 0) × p
-#     if norm(aux) == T(0) # rotation to -ex         
-#         rotAxis = SVector{3,T}(0, 1, 0) # rotate around y-axis
-#     else # all other cases
-#         rotAxis = normalize(aux)
-#     end
-
-#     cosϑ = p[1]                     # inner product of unit vectors:  ex ⋅ p  = p[1] = cos(ϑ)
-#     sinϑ = sqrt(p[2]^2 + p[3]^2)    # cross product of unit vectors: |ex × p| = sin(ϑ)
-
-#     # --- auxiliary matrix
-#     K = SMatrix{3,3,T}([
-#          0          -rotAxis[3]  rotAxis[2]
-#          rotAxis[3]  0          -rotAxis[1]
-#         -rotAxis[2]  rotAxis[1]  0
-#     ])
-
-#     # --- put it together
-#     R = I + sinϑ * K + (1 - cosϑ) * K * K  # Rodriguez rotation formula
-
-#     return R
-# end
 
 
 """

--- a/src/dataHandling.jl
+++ b/src/dataHandling.jl
@@ -10,11 +10,19 @@ struct ElectricField <: Field
     locations#::Vector
 end
 
+struct DisplacementField <: Field
+    locations#::Vector
+end
+
 struct MagneticField <: Field
     locations#::Vector
 end
 
 struct ScalarPotential <: Field
+    locations
+end
+
+struct ScalarPotentialJump <: Field
     locations
 end
 

--- a/src/dipoles/excitation.jl
+++ b/src/dipoles/excitation.jl
@@ -112,3 +112,7 @@ function getFieldType(excitation::FitzgeraldDipole, quantity::Field)
         return quantity, exc
     end
 end
+
+function orientation(ex::Dipole)
+    return ex.orientation
+end

--- a/src/dipoles/incident.jl
+++ b/src/dipoles/incident.jl
@@ -8,7 +8,7 @@ function field(excitation::Dipole, quantity::Field; parameter::Parameter=Paramet
 
     T = typeof(excitation.frequency)
 
-    F = zeros(SVector{3,Complex{T}}, length(quantity.locations))
+    F = zeros(SVector{3,Complex{T}}, size(quantity.locations))
 
     # --- distinguish electric/magnetic current
     fieldType, exc = getFieldType(excitation, quantity)

--- a/src/planeWave/incident.jl
+++ b/src/planeWave/incident.jl
@@ -8,7 +8,7 @@ function field(excitation::PlaneWave, quantity::Field; parameter::Parameter=Para
 
     T = typeof(excitation.frequency)
 
-    F = zeros(SVector{3,Complex{T}}, length(quantity.locations))
+    F = zeros(SVector{3,Complex{T}}, size(quantity.locations))
 
     # --- compute field in Cartesian representation
     for (ind, point) in enumerate(quantity.locations)

--- a/src/ringCurrent/excitation.jl
+++ b/src/ringCurrent/excitation.jl
@@ -125,3 +125,6 @@ function getFieldType(excitation::MagneticRingCurrent, quantity::Field)
     end
 end
 
+function orientation(ex::RingCurrent)
+    return ex.orientation
+end

--- a/src/ringCurrent/incident.jl
+++ b/src/ringCurrent/incident.jl
@@ -7,7 +7,7 @@ Compute the electric field radiated by a magnetic/electric ring current at some 
 function field(excitation::RingCurrent, quantity::Field; parameter::Parameter=Parameter())
 
     T = typeof(excitation.frequency)
-    F = zeros(SVector{3,Complex{T}}, length(quantity.locations))
+    F = zeros(SVector{3,Complex{T}}, size(quantity.locations))
 
     # --- distinguish electric/magnetic current
     fieldType, exc = getFieldType(excitation, quantity)

--- a/src/sphere.jl
+++ b/src/sphere.jl
@@ -49,6 +49,49 @@ DielectricSphere(; radius=error("missing argument `radius`"), embedding=Medium(�
     DielectricSphere(radius, embedding, filling)
 
 
+
+struct DielectricSphereThinImpedanceLayer{R,C} <: Sphere
+    radius::R
+    thickness::R
+    embedding::Medium{C}
+    thinlayer::Medium{C}
+    filling::Medium{C}
+end
+
+function DielectricSphereThinImpedanceLayer(
+    r::R1, d::R2, embedding::Medium{C1}, thinlayer::Medium{C2}, filling::Medium{C3}
+) where {R1,R2,C1,C2,C3}
+
+    R = promote_type(R1, R2)
+    C = promote_type(C1, C2, C3)
+
+    DielectricSphereThinImpedanceLayer(R(r), R(d), Medium{C}(embedding), Medium{C}(thinlayer), Medium{C}(filling))
+end
+
+"""
+    DielectricSphereThinImpedanceLayer(
+        radius      = error("missing argument `radius`"),
+        thickness   = error("missing argument `thickness` of the coating"),
+        embedding   = Medium(ε0, μ0),
+        thinlayer   = error("missing argument `thinlayer`"),
+        filling     = error("missing argument `filling`")
+    )
+
+Constructor for the dielectric sphere with a thin impedance layer.
+For this model, it is assumed that the displacement field is only radial
+direction in the layer, which requires a small thickness and low conductivity.
+For details, see for example T. B. Jones, Ed., “Models for layered spherical particles,”
+in Electromechanics of Particles, Cambridge: Cambridge University Press, 1995, 
+pp. 227–235. doi: 10.1017/CBO9780511574498.012.
+"""
+DielectricSphereThinImpedanceLayer(;
+    radius=error("missing argument `radius`"),
+    thickness=error("missing argument `thickness` of the coating"),
+    embedding=Medium(ε0, μ0),
+    thinlayer=error("missing argument `thinlayer`"),
+    filling=error("missing argument `filling`"),
+) = DielectricSphereThinImpedanceLayer(radius, thickness, embedding, thinlayer, filling)
+
 struct PECSphere{C,R} <: Sphere
     radius::R
     embedding::Medium{C}

--- a/src/sphericalModes/incident.jl
+++ b/src/sphericalModes/incident.jl
@@ -7,7 +7,7 @@ Compute the electric field of a spherical mode.
 function field(excitation::SphericalMode, quantity::Field; parameter::Parameter=Parameter())
 
     T = typeof(excitation.frequency)
-    F = zeros(SVector{3,Complex{T}}, length(quantity.locations))
+    F = zeros(SVector{3,Complex{T}}, size(quantity.locations))
 
     # --- distinguish electric/magnetic field
     fieldType, exc = getFieldType(excitation, quantity)

--- a/test/uniformField.jl
+++ b/test/uniformField.jl
@@ -115,4 +115,84 @@ end
         @test E[3][2] ≈ -215 / 512
         @test E[3][3] ≈ 129 / 512
     end
+    @testset "Dielectric sphere with thin impedance layer" begin
+        # Free-space permittivity
+        ε₀ = 8.854187812813e-18 # F µm⁻¹ - > 8.854.. * e-12 F m⁻¹
+        E₀ = 1e-6
+        # Radius of cell
+        R_c = 1 # µm
+        Δ = 5e-3 #5e-3 # µm Membrane thickness
+
+        # Permittivity and conductivity outside (suspension)
+        ε_s = 80 #
+        σ_s = 1e-6 # S / µm --> 1 S / m
+
+        #
+        ε_m = 10 # Permittivity
+        σ_m = 1e-12 # S / µm --> 1e-6 S / m
+
+        σ_c = 1e-6
+
+        f = 1e7
+        ω = 2 * π * f
+
+        # Assume exp(im*ω*t)-time dependency
+        md_s = Medium(ε_s * ε₀ + im * (σ_s / ω), σ_s)
+        md_m = Medium(ε_m * ε₀ + im * (σ_m / ω), σ_m)
+        md_c = Medium(ε_s * ε₀ + im * (σ_c / ω), σ_m)
+
+        #
+        sp = LayeredSphere(;
+            radii=SVector(R_c, R_c - Δ), # Radius of total cell, then radius of core of cell (or should we do it differently?)
+            embedding=md_s, # Suspension
+            filling=SVector(md_m, md_c), # From outer to inner layer
+        )
+
+
+        spj = DielectricSphereThinImpedanceLayer(;
+            radius=R_c, # Radius of total cell, then radius of core of cell (or should we do it differently?)
+            thickness=Δ,
+            embedding=md_s, # Suspension
+            thinlayer=md_m,
+            filling=md_c, # From outer to inner layer
+        )
+
+        # We compare against Jones, 1995, Appendix, he uses E₀ẑ
+        # So potential points (i.e., grows) into ẑ direction
+        potential_direction = SVector{3,Float64}(0.0, 0.0, -1.0)
+
+        ex = UniformField(;
+            embedding = md_s,
+            amplitude = E₀,
+            direction = -potential_direction, # field will point in opposite direction
+        )
+
+        Φsca_ana_3l(pts) = scatteredfield(sp, ex, ScalarPotential(pts))
+        Φtot_ana_3l(pts) = field(sp, ex, ScalarPotential(pts))
+        ∇Φsca_ana_3l(pts) = scatteredfield(sp, ex, ElectricField(pts)) # I want the gradient, not the electric field
+
+        Φsca_ana_app(pts) = scatteredfield(spj, ex, ScalarPotential(pts))
+        Φtot_ana_app(pts) = field(spj, ex, ScalarPotential(pts))
+        ∇Φsca_ana_app(pts) = scatteredfield(spj, ex, ElectricField(pts)) # I want the gradient, not the electric field
+
+        @test norm(Φsca_ana_app(points_cartNF) - Φsca_ana_3l(points_cartNF)) / norm(Φsca_ana_3l(points_cartNF)) < 0.007
+        @test norm(∇Φsca_ana_app(points_cartNF) - ∇Φsca_ana_3l(points_cartNF)) / norm(∇Φsca_ana_3l(points_cartNF)) < 0.007
+
+        # Jump of potential should be comparable to the exact model
+        ΔΦ_3l(pts) = Φtot_ana_3l(pts ./ norm.(pts) .* ((R_c - Δ))) .- Φtot_ana_3l(pts ./ norm.(pts) .* R_c)
+        ΔΦ(pts) = scatteredfield(spj, ex, ScalarPotentialJump(pts))
+
+        tmp_approx_relerror(pts) = norm(ΔΦ(pts) - ΔΦ_3l(pts)) / norm(ΔΦ_3l(pts))
+
+        tmp_approx_relerror(points_cartNF) < 0.0015
+
+        ε∇Φsca_ana_app(pts) = scatteredfield(spj, ex, DisplacementField(pts))
+
+        Etot(pts) = field(spj, ex, ElectricField(pts))
+        𝒏 = points_cartFF ./ norm.(points_cartFF)
+        absdiff = dot.(𝒏, spj.embedding.ε * Etot(points_cartFF .* 1.01) - ε∇Φsca_ana_app(points_cartFF .* 0.99))
+
+        # Check that normal component of D-field is continuous
+        @test norm(absdiff) / norm(dot.(𝒏, ε∇Φsca_ana_app(points_cartFF .* 0.99))) < 0.02
+    end
 end

--- a/test/uniformField.jl
+++ b/test/uniformField.jl
@@ -143,29 +143,19 @@ end
 
         #
         sp = LayeredSphere(;
-            radii=SVector(R_c, R_c - Δ), # Radius of total cell, then radius of core of cell (or should we do it differently?)
-            embedding=md_s, # Suspension
+            radii=SVector(R_c, R_c - Δ),
+            embedding=md_s,
             filling=SVector(md_m, md_c), # From outer to inner layer
         )
 
 
-        spj = DielectricSphereThinImpedanceLayer(;
-            radius=R_c, # Radius of total cell, then radius of core of cell (or should we do it differently?)
-            thickness=Δ,
-            embedding=md_s, # Suspension
-            thinlayer=md_m,
-            filling=md_c, # From outer to inner layer
-        )
+        spj = DielectricSphereThinImpedanceLayer(; radius=R_c, thickness=Δ, embedding=md_s, thinlayer=md_m, filling=md_c)
 
         # We compare against Jones, 1995, Appendix, he uses E₀ẑ
         # So potential points (i.e., grows) into ẑ direction
-        potential_direction = SVector{3,Float64}(0.0, 0.0, -1.0)
+        potential_direction = dir
 
-        ex = UniformField(;
-            embedding = md_s,
-            amplitude = E₀,
-            direction = -potential_direction, # field will point in opposite direction
-        )
+        ex = UniformField(; embedding=md_s, amplitude=E₀, direction=-potential_direction)
 
         Φsca_ana_3l(pts) = scatteredfield(sp, ex, ScalarPotential(pts))
         Φtot_ana_3l(pts) = field(sp, ex, ScalarPotential(pts))


### PR DESCRIPTION
   Add dielectric sphere with impedance layer
    
    The dielectric sphere has an impedance layer. As a consequence,
    the potential is discontinuous at the interface, but the radial
    displacement field is still continuous.
    
    This approximation is commonly used in BioEM to model cells with
    their resistive membranes.
    
    The approximation is useful to observe convergence of numerical
    algorithms that use a similar thin layer approximation (and
    which would not converge to the full three layer problem)